### PR TITLE
Call .perl(:arglist) for Capture's list elements

### DIFF
--- a/src/core.c/Capture.pm6
+++ b/src/core.c/Capture.pm6
@@ -110,7 +110,7 @@ my class Capture { # declared in BOOTSTRAP
         if self.^name eq 'Capture' {
             "\\({
                 join ', ',
-                    ((nqp::atpos(@!list, $_).perl for ^nqp::elems(@!list)) if @!list),
+                    ((nqp::atpos(@!list, $_).perl(:arglist) for ^nqp::elems(@!list)) if @!list),
                     %hash.sort.map( *.perl )
             })";
         } else {


### PR DESCRIPTION
This change causes `Capture.perl` to output pair objects with proper syntax:

```
> say \('a'=>1, a=>2).perl
\("a" => 1, :a(2))
```

Pass spectests. Fix #3258.

It could be made more selective and only pass `:arglist` to pair objects, but maybe it's not worth it:
```perl6
my $elem;
# ...
((nqp::istype(($elem := nqp::atpos(@!list, $_)), Pair)
  ?? $elem.perl(:arglist)
  !! $elem.perl
  for ^nqp::elems(@!list)) if @!list),
```
